### PR TITLE
DOC: backslash in docstring

### DIFF
--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -420,9 +420,9 @@ function vcat(ops :: AbstractLinearOperator...)
 end
 
 
-@doc """Inverse of a matrix as a linear operator using `\`.
+@doc """Inverse of a matrix as a linear operator using `\\`.
 Useful for triangular matrices. Note that each application of this
-operator applies `\`.""" ->
+operator applies `\\`.""" ->
 opInverse(M :: KindOfMatrix; symmetric=false, hermitian=false) =
   LinearOperator(size(M,2), size(M,1), typeof(M[1,1]), symmetric, hermitian,
                  v -> M \ v, u -> M.' \ u, w -> M' \ w);


### PR DESCRIPTION
The intention is to fix markup/escape problems in the docstring, for example as seen [here](https://dpo.github.io/LinearOperators.jl/LinearOperators.html#opInverse(M::Union(Array{T, N}, SparseMatrixCSC{Tv, Ti<:Integer})))

I wasn't able to test it due to issue https://github.com/dpo/LinearOperators.jl/issues/5 and my Julia newbie-ness.